### PR TITLE
Revert "Add option to send application environment variables as custom container tags"

### DIFF
--- a/jobs/datadog-cluster-agent/spec
+++ b/jobs/datadog-cluster-agent/spec
@@ -90,9 +90,3 @@ properties:
   cloud_foundry_api.no_proxy:
     default: []
     description: List of domains for which requests should skip proxy.
-  cloud_foundry_bbs.env_include:
-    default: []
-    description: List of regular expressions to allow a set of environment variables to be included as container tags.	
-  cloud_foundry_bbs.env_exclude:
-    default: []
-    description: List of regular expressions to forbid a set of environment variables to be included as container tags.

--- a/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
+++ b/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
@@ -23,8 +23,6 @@ cloud_foundry_bbs:
   ca_file: "/var/vcap/jobs/datadog-cluster-agent/config/bbs_ca.crt"
   cert_file: "/var/vcap/jobs/datadog-cluster-agent/config/bbs_client.crt"
   key_file: "/var/vcap/jobs/datadog-cluster-agent/config/bbs_client.key"
-  env_include: <%= p("cloud_foundry_bbs.env_include", []) %>
-  env_exclude: <%= p("cloud_foundry_bbs.env_exclude", []) %>
 
 config_providers:
   - name: cloudfoundry-bbs


### PR DESCRIPTION
Reverts DataDog/datadog-cluster-agent-boshrelease#16

I'd like to make a 7.26 release first.