### PR TITLE
Add option to serve nozzle data

### DIFF
--- a/jobs/datadog-cluster-agent/spec
+++ b/jobs/datadog-cluster-agent/spec
@@ -65,6 +65,9 @@ properties:
     description: |
       Cloud Foundry API integration YAML configuration. See [example configuration](http://github.com/DataDog/integrations-core/blob/master/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example) for all available options.
       Use this instead of the following individual properties for full customization of the integration.
+  cluster_agent.serve_nozzle_data:
+    default: false
+    description: Whether or not to serve data for the nozzles.
   cloud_foundry_api.api_url:
     default: ""
     description: Cloud Foundry API URL where the integration collects events.

--- a/jobs/datadog-cluster-agent/spec
+++ b/jobs/datadog-cluster-agent/spec
@@ -67,7 +67,7 @@ properties:
       Use this instead of the following individual properties for full customization of the integration.
   cluster_agent.serve_nozzle_data:
     default: false
-    description: Whether or not to serve data for the nozzles.
+    description: Whether or not to serve preprocessed data for the nozzles.
   cloud_foundry_api.api_url:
     default: ""
     description: Cloud Foundry API URL where the integration collects events.

--- a/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
+++ b/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
@@ -15,6 +15,7 @@ cluster_checks:
 cluster_agent:
   cmd_port: <%= p('cluster_agent.port') %>
   auth_token: "<%= p('cluster_agent.token') %>"
+  serve_nozzle_data: <%= p('cluster_agent.serve_nozzle_data') %>
 
 cloud_foundry: true
 

--- a/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
+++ b/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
@@ -28,7 +28,7 @@ cloud_foundry_bbs:
   env_include: <%= p("cloud_foundry_bbs.env_include", []) %>
   env_exclude: <%= p("cloud_foundry_bbs.env_exclude", []) %>
 
-<% if p("cluster_agent.enable_cloud_foundry_api_apps_polling") %>
+<% if p("cluster_agent.enable_cloud_foundry_api_apps_polling") or p('cluster_agent.serve_nozzle_data') %>
 cloud_foundry_cc:
   url: <%= p("cloud_foundry_api.api_url") %>
   client_id: <%= p("cloud_foundry_api.client_id") %>


### PR DESCRIPTION
Add option for the [serve_nozzle_data](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config.go#L661) property in the cluster agent.