### PR TITLE
Revert "Add option to enable advanced tagging (#36)"

### DIFF
--- a/jobs/datadog-cluster-agent/spec
+++ b/jobs/datadog-cluster-agent/spec
@@ -68,9 +68,6 @@ properties:
   cluster_agent.serve_nozzle_data:
     default: false
     description: Whether or not to serve preprocessed data for the nozzles.
-  cluster_agent.advanced_tagging:
-    default: false
-    decscription: Whether or not to collect extra tags such as `sidecar_present` and `sidecar_count` for containers.
   cloud_foundry_api.api_url:
     default: ""
     description: Cloud Foundry API URL where the integration collects events.

--- a/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
+++ b/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
@@ -16,7 +16,6 @@ cluster_agent:
   cmd_port: <%= p('cluster_agent.port') %>
   auth_token: "<%= p('cluster_agent.token') %>"
   serve_nozzle_data: <%= p('cluster_agent.serve_nozzle_data') %>
-  advanced_tagging: <%= p('cluster_agent.advanced_tagging') %>
 
 cloud_foundry: true
 
@@ -29,7 +28,7 @@ cloud_foundry_bbs:
   env_include: <%= p("cloud_foundry_bbs.env_include", []) %>
   env_exclude: <%= p("cloud_foundry_bbs.env_exclude", []) %>
 
-<% if p("cluster_agent.enable_cloud_foundry_api_apps_polling") or p('cluster_agent.serve_nozzle_data') or p('cluster_agent.advanced_tagging') %>
+<% if p("cluster_agent.enable_cloud_foundry_api_apps_polling") or p('cluster_agent.serve_nozzle_data') %>
 cloud_foundry_cc:
   url: <%= p("cloud_foundry_api.api_url") %>
   client_id: <%= p("cloud_foundry_api.client_id") %>


### PR DESCRIPTION
Requires `7.36.x` agent version.