### PR TITLE
Add `refresh_on_cache_miss`, `sidecars_tags` and `isolation_segments_tags` properties

### DIFF
--- a/jobs/datadog-cluster-agent/spec
+++ b/jobs/datadog-cluster-agent/spec
@@ -70,7 +70,13 @@ properties:
     description: Whether or not to serve preprocessed data for the nozzles.
   cluster_agent.advanced_tagging:
     default: false
+    decscription: Whether or not to collect all extra tags (sidecars, isolation segments) for containers.
+  cluster_agent.sidecars_tags:
+    default: false
     decscription: Whether or not to collect extra tags such as `sidecar_present` and `sidecar_count` for containers.
+  cluster_agent.isolation_segments_tags:
+    default: false
+    decscription: Whether or not to collect extra tags such as `segment_id` and `segment_name` for containers.
   cloud_foundry_api.api_url:
     default: ""
     description: Cloud Foundry API URL where the integration collects events.

--- a/jobs/datadog-cluster-agent/spec
+++ b/jobs/datadog-cluster-agent/spec
@@ -77,6 +77,9 @@ properties:
   cluster_agent.isolation_segments_tags:
     default: false
     decscription: Whether or not to collect extra tags such as `segment_id` and `segment_name` for containers.
+  cluster_agent.refresh_on_cache_miss:
+    default: false
+    description: Whether or not to query the CAPI on cache misses in the cluster agent.
   cloud_foundry_api.api_url:
     default: ""
     description: Cloud Foundry API URL where the integration collects events.

--- a/jobs/datadog-cluster-agent/spec
+++ b/jobs/datadog-cluster-agent/spec
@@ -79,7 +79,7 @@ properties:
     decscription: Whether or not to collect extra tags such as `segment_id` and `segment_name` for containers.
   cluster_agent.refresh_on_cache_miss:
     default: false
-    description: Whether or not to query the CAPI on cache misses in the cluster agent.
+    description: Whether or not to query the CAPI on cache miss in the cluster agent.
   cloud_foundry_api.api_url:
     default: ""
     description: Cloud Foundry API URL where the integration collects events.

--- a/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
+++ b/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
@@ -16,7 +16,9 @@ cluster_agent:
   cmd_port: <%= p('cluster_agent.port') %>
   auth_token: "<%= p('cluster_agent.token') %>"
   serve_nozzle_data: <%= p('cluster_agent.serve_nozzle_data') %>
-  advanced_tagging: <%= p('cluster_agent.advanced_tagging') %>
+  sidecars_tags: <%= p('cluster_agent.sidecars_tags') || p('cluster_agent.advanced_tags') %>
+  isolation_segments_tags: <%= p('cluster_agent.isolation_segments_tags')  || p('cluster_agent.advanced_tags')  %>
+  refresh_on_cache_miss: <%= p('cluster_agent.refresh_on_cache_miss') %>
 
 cloud_foundry: true
 


### PR DESCRIPTION
Splits the `advanced_tagging` property into `sidecars_tags` and `isolation_segments_tags` to enable finer control.
We're keeping the `advanced_tagging` property for backward compatibility.