### PR TITLE
Update CODEOWNERS - remove docs team courtesy reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 *                       @DataDog/platform-integrations
 
 # Documentation
-*.md                    @DataDog/documentation @DataDog/platform-integrations
+*.md                    @DataDog/platform-integrations


### PR DESCRIPTION


### What does this PR do?

The Datadog docs team has in the past offered to do courtesy reviews on engineering-owned content. However, we are refining our scope and removing courtesy reviews.



### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
