### PR TITLE
Fix clusterchecks dispatching

### DIFF
--- a/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
+++ b/jobs/datadog-cluster-agent/templates/datadog-cluster.yaml.erb
@@ -48,7 +48,7 @@ config_providers:
     polling: true
 
 listeners:
-  - name: cloudfoundry-bbs
+  - name: cloudfoundry_bbs # TODO: temporary fix, revert to cloudfoundry-bbs after agent 7.66
 
 leader_election: false
 <% end %>


### PR DESCRIPTION
This PR fixes the Cloud Foundry listener name that was changed by accident on the datadog-agent side.